### PR TITLE
API: Check UserModel::IsDisabled when processing game state

### DIFF
--- a/API/GameState/Functions/GameStateFunction.cs
+++ b/API/GameState/Functions/GameStateFunction.cs
@@ -64,7 +64,7 @@ namespace CSGOTunes.API.GameState.Functions
 
             var user = await this.userRepository.GetByIDAsync(spotifyUserID, cancellationToken);
 
-            if (user == null || user.CFGKey != cfgKey)
+            if (user == null || user.CFGKey != cfgKey || user.IsDisabled)
             {
                 return new NotFoundResult();
             }


### PR DESCRIPTION
This commit makes sure the game state endpoint should exit-early if the user currently has the application disabled.

This fixed #3 