### PR TITLE
API: Offload processing of Game State processing to queue function

### DIFF
--- a/API/GameState/Functions/PostGameStateFunction.cs
+++ b/API/GameState/Functions/PostGameStateFunction.cs
@@ -1,0 +1,81 @@
+// <copyright file="PostGameStateFunction.cs" company="CS:GO Tunes">
+// Copyright (c) CS:GO Tunes. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using CSGOTunes.API.Extensions;
+using CSGOTunes.API.GameState.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace CSGOTunes.API.GameState.Functions
+{
+    /// <summary>
+    /// Processing incoming POST requests for game-state integration events.
+    /// </summary>
+    public sealed class PostGameStateFunction
+    {
+        private readonly QueueServiceClient queueServiceClient;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PostGameStateFunction"/> class.
+        /// </summary>
+        /// <param name="queueServiceClient">An instance of <see cref="QueueServiceClient"/>.</param>
+        public PostGameStateFunction(QueueServiceClient queueServiceClient)
+        {
+            this.queueServiceClient = queueServiceClient;
+        }
+
+        /// <summary>
+        /// Run the function and complete authentication.
+        /// </summary>
+        /// <param name="httpRequest">An instance of <see cref="HttpRequest"/>.</param>
+        /// <param name="log">An instance of <see cref="ILogger"/>.</param>
+        /// <param name="cancellationToken">An instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>An instance of <see cref="NoContentResult"/>.</returns>
+        [FunctionName(nameof(PostGameStateFunction))]
+        public async Task<IActionResult> RunAsync(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "game-state")]
+            HttpRequest httpRequest,
+            ILogger log,
+            CancellationToken cancellationToken)
+        {
+            var spotifyUserID = httpRequest.Query["spotifyUserID"].FirstOrDefault() ?? string.Empty;
+            var cfgKey = httpRequest.Query["cfgKey"].FirstOrDefault() ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(spotifyUserID) || string.IsNullOrWhiteSpace(cfgKey))
+            {
+                return new NotFoundResult();
+            }
+
+            var (gameStateRequest, modelState) = await httpRequest.ReadAndValidateAsync<GameStateRequestModel>(cancellationToken);
+
+            if (gameStateRequest == null || !modelState.IsValid)
+            {
+                return new BadRequestObjectResult(new ValidationProblemDetails(modelState));
+            }
+
+            var queueClient = this.queueServiceClient.GetQueueClient("game-state");
+            await queueClient.SendMessageAsync(
+                Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new GameStateEventModel
+                {
+                    SpotifyUserID = spotifyUserID,
+                    CFGKey = cfgKey,
+                    Request = gameStateRequest,
+                }))),
+                TimeSpan.Zero,
+                cancellationToken: cancellationToken);
+
+            return new NoContentResult();
+        }
+    }
+}

--- a/API/GameState/Models/GameStateEventModel.cs
+++ b/API/GameState/Models/GameStateEventModel.cs
@@ -1,0 +1,27 @@
+// <copyright file="GameStateEventModel.cs" company="CS:GO Tunes">
+// Copyright (c) CS:GO Tunes. All rights reserved.
+// </copyright>
+
+namespace CSGOTunes.API.GameState.Models
+{
+    /// <summary>
+    /// A game-state integration event, which is queued and processed.
+    /// </summary>
+    public sealed record GameStateEventModel
+    {
+        /// <summary>
+        /// Gets the Spotify user ID for the event.
+        /// </summary>
+        public string? SpotifyUserID { get; init; }
+
+        /// <summary>
+        /// Gets the CFG key for the event.
+        /// </summary>
+        public string? CFGKey { get; init; }
+
+        /// <summary>
+        /// Gets the game state request.
+        /// </summary>
+        public GameStateRequestModel? Request { get; init; }
+    }
+}

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -43,6 +43,7 @@ namespace CSGOTunes.API
             {
                 var azureConnectionString = builder.GetContext().Configuration["AzureWebJobsStorage"];
                 clientFactoryBuilder.AddTableServiceClient(azureConnectionString);
+                clientFactoryBuilder.AddQueueServiceClient(azureConnectionString);
             });
 
             // Register our repositories

--- a/API/host.json
+++ b/API/host.json
@@ -6,5 +6,8 @@
                 "isEnabled": true
             }
         }
+    },
+    "queues": {
+        "maxDequeueCount": 1
     }
 }

--- a/Infrastructure/csgotunes.json
+++ b/Infrastructure/csgotunes.json
@@ -85,6 +85,17 @@
             ]
         },
         {
+            "type": "queueServices/queues",
+            "apiVersion": "2019-06-01",
+            "name": "default/game-state",
+            "properties": {
+                "metadata": {}
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('defaultResourceName'))]"
+            ]
+        },
+        {
             "apiVersion": "2018-05-01-preview",
             "name": "[variables('defaultResourceName')]",
             "type": "Microsoft.Insights/components",

--- a/Meta/Scripts/CreateLocalStorageResources.ps1
+++ b/Meta/Scripts/CreateLocalStorageResources.ps1
@@ -3,3 +3,4 @@ $StorageContext = New-AzStorageContext -ConnectionString "DefaultEndpointsProtoc
 New-AzStorageTable -Name "users" -Context $StorageContext
 New-AzStorageTable -Name "nonces" -Context $StorageContext
 New-AzStorageTable -Name "sessions" -Context $StorageContext
+New-AzStorageQueue –Name "game-state" -Context $storageContext


### PR DESCRIPTION
This is a performance optimization to ensure that the HTTP triggers return as fast as possible. We do not perform any API calls within them, and instead post a message to the storage queue named `game-state`. Then another function is able to pick up items off that queue and process them without holding up the HTTP clients.