### PR TITLE
Website: Add a download CFG button to the dashboard

### DIFF
--- a/Website/Source/Models/UserProfileResponse.ts
+++ b/Website/Source/Models/UserProfileResponse.ts
@@ -1,0 +1,6 @@
+export interface UserProfileResponse {
+  spotifyUserID: string
+  cfgKey: string
+  lastSeenAt: string
+  isDisabled: string
+}

--- a/Website/Source/Pages/CallbackPage.tsx
+++ b/Website/Source/Pages/CallbackPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { getApiBaseUrl, isNullOrWhitespace } from '../Utils';
 import { CompleteAuthResponse } from '../Models/CompleteAuthResponse';
 import { useHistory } from 'react-router-dom';
+import { setSession } from '../Utils/AuthUtils';
 
 export const CallbackPage: React.FunctionComponent<any> = () => {
   const history = useHistory();
@@ -34,7 +35,7 @@ export const CallbackPage: React.FunctionComponent<any> = () => {
       }
 
       const completeAuthResponse: CompleteAuthResponse = await response.json();
-      localStorage.setItem('CSGOTunesAuthToken', completeAuthResponse.sessionID);
+      setSession(completeAuthResponse.sessionID);
 
       // FIXME: This is a hack to remove the query string parameters.
       // For some reason, when you try to use `history.replace` it does not work properly.

--- a/Website/Source/Pages/DashboardPage.tsx
+++ b/Website/Source/Pages/DashboardPage.tsx
@@ -1,21 +1,89 @@
-import React, { useEffect } from 'react';
+import React, { MouseEvent, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { getApiBaseUrl } from '../Utils';
+import { UserProfileResponse } from '../Models/UserProfileResponse';
+import FileSaver from 'file-saver';
+import { clearSession, getSession } from '../Utils/AuthUtils';
 
 export const DashboardPage: React.FunctionComponent<any> = () => {
   const history = useHistory();
+  const [isDownloadingConfig, setDownloadingConfig] = useState(false);
 
   useEffect(() => {
-    const sessionId = localStorage.getItem('CSGOTunesAuthToken');
+    const sessionId = getSession();
 
-    if (sessionId === null || sessionId.trim() === '') {
-      localStorage.removeItem('CSGOTunesAuthToken');
+    if (sessionId === null) {
+      clearSession();
       history.push('/login');
     }
   }, []);
 
+  const downloadConfig = (e: MouseEvent<HTMLButtonElement>): void => {
+    void (async function () {
+      try {
+        const sessionId = getSession();
+
+        if (sessionId === null) {
+          return;
+        }
+
+        const requestOptions = {
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${sessionId}` }
+        };
+
+        setDownloadingConfig(true);
+        const response = await fetch(getApiBaseUrl() + '/user-profile', requestOptions);
+
+        if (response.status >= 400) {
+          console.log('Oh, no!');
+        }
+
+        const userProfileResponse: UserProfileResponse = await response.json();
+        const encodedSpotifyUserId = encodeURIComponent(userProfileResponse.spotifyUserID);
+        const encodedCFGKey = encodeURIComponent(userProfileResponse.cfgKey);
+
+        const userConfig = `
+"CS:GO Tunes"
+{
+ "uri" "https://csgotunes.azurewebsites.net/api/game-state?spotifyUserID=${encodedSpotifyUserId}&cfgKey=${encodedCFGKey}"
+ "timeout" "5.0"
+ "buffer"  "0.1"
+ "throttle" "0.5"
+ "heartbeat" "60.0"
+ "output"
+ {
+   "precision_time" "3"
+   "precision_position" "1"
+   "precision_vector" "3"
+ }
+ "data"
+ {
+   "provider"            "1"      // general info about client being listened to: game name, appid, client steamid, etc.
+   "map"                 "1"      // map, gamemode, and current match phase ('warmup', 'intermission', 'gameover', 'live') and current score
+   "round"               "1"      // round phase ('freezetime', 'over', 'live'), bomb state ('planted', 'exploded', 'defused'), and round winner (if any)
+   "player_id"           "1"      // player name, clan tag, observer slot (ie key to press to observe this player) and team
+   "player_state"        "1"      // player state for this current round such as health, armor, kills this round, etc.
+   "player_weapons"      "1"      // output equipped weapons.
+   "player_match_stats"  "1"      // player stats this match such as kill, assists, score, deaths and MVPs
+ }
+}
+        `;
+
+        const blob = new Blob([userConfig], {
+          type: 'text/plain;charset=utf-8'
+        });
+        FileSaver.saveAs(blob, 'gamestate_integration_csgotunes.cfg');
+      } finally {
+        setDownloadingConfig(false);
+      }
+    })();
+  };
+
   return (
     <div>
       <p>Welcome to the dashboard.</p>
+      <button onClick={downloadConfig} disabled={isDownloadingConfig}>Download CFG</button>
     </div>
   );
 };

--- a/Website/Source/Pages/HomePage.tsx
+++ b/Website/Source/Pages/HomePage.tsx
@@ -1,14 +1,15 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
+import { clearSession, getSession } from '../Utils/AuthUtils';
 
 export const HomePage: React.FunctionComponent<any> = () => {
   const history = useHistory();
 
   useEffect(() => {
-    const sessionId = localStorage.getItem('CSGOTunesAuthToken');
+    const sessionId = getSession();
 
-    if (sessionId === null || sessionId.trim() === '') {
-      localStorage.removeItem('CSGOTunesAuthToken');
+    if (sessionId === null) {
+      clearSession();
       history.push('/login');
       return;
     }

--- a/Website/Source/Pages/LoginPage.tsx
+++ b/Website/Source/Pages/LoginPage.tsx
@@ -4,15 +4,16 @@ import { InitAuthResponse } from '../Models/InitAuthResponse';
 import { getApiBaseUrl } from '../Utils';
 import { Header } from '../Components/Header';
 import { Footer } from '../Components/Footer';
+import { getSession } from '../Utils/AuthUtils';
 
 export const LoginPage: React.FunctionComponent<any> = () => {
   const history = useHistory();
   const [loggingIn, setLoggingIn] = useState<boolean>(false);
 
   useEffect(() => {
-    const sessionId = localStorage.getItem('CSGOTunesAuthToken');
+    const sessionId = getSession();
 
-    if (sessionId !== null && sessionId.trim() !== '') {
+    if (sessionId !== null) {
       history.push('/dashboard');
     }
   }, []);

--- a/Website/Source/Pages/LogoutPage.tsx
+++ b/Website/Source/Pages/LogoutPage.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
+import { clearSession } from '../Utils/AuthUtils';
 
 export const LogoutPage: React.FunctionComponent<any> = () => {
   const history = useHistory();
 
   useEffect(() => {
-    localStorage.removeItem('CSGOTunesAuthToken');
+    clearSession();
     history.push('/login');
   }, []);
 

--- a/Website/Source/Utils/AuthUtils.ts
+++ b/Website/Source/Utils/AuthUtils.ts
@@ -1,0 +1,23 @@
+export const getSession = (): string | null => {
+  let sessionId = localStorage.getItem('CSGOTunesAuthToken');
+
+  if (sessionId === null || sessionId === undefined) {
+    return null;
+  }
+
+  sessionId = sessionId.trim();
+
+  if (sessionId === '') {
+    return null;
+  }
+
+  return sessionId;
+};
+
+export const setSession = (sessionId: string): void => {
+  localStorage.setItem('CSGOTunesAuthToken', sessionId);
+};
+
+export const clearSession = (): void => {
+  localStorage.removeItem('CSGOTunesAuthToken');
+};

--- a/Website/package-lock.json
+++ b/Website/package-lock.json
@@ -11,12 +11,14 @@
       "dependencies": {
         "bootstrap": "^5.2.0",
         "bootstrap-icons": "^1.9.1",
+        "file-saver": "^2.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router": "^5.3.3",
         "react-router-dom": "^5.3.3"
       },
       "devDependencies": {
+        "@types/file-saver": "^2.0.5",
         "@types/node": "^18.7.13",
         "@types/react": "^18.0.17",
         "@types/react-dom": "^18.0.6",
@@ -1824,6 +1826,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@types/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
+      "dev": true
+    },
     "node_modules/@types/history": {
       "version": "4.7.11",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
@@ -3347,6 +3355,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -6596,6 +6609,12 @@
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "dev": true
     },
+    "@types/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
+      "dev": true
+    },
     "@types/history": {
       "version": "4.7.11",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
@@ -7691,6 +7710,11 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
+    },
+    "file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/Website/package.json
+++ b/Website/package.json
@@ -30,16 +30,18 @@
   "dependencies": {
     "bootstrap": "^5.2.0",
     "bootstrap-icons": "^1.9.1",
+    "file-saver": "^2.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router": "^5.3.3",
     "react-router-dom": "^5.3.3"
   },
   "devDependencies": {
+    "@types/file-saver": "^2.0.5",
+    "@types/node": "^18.7.13",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
     "@types/react-router-dom": "^5.3.3",
-    "@types/node": "^18.7.13",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "eslint": "^8.22.0",
     "eslint-config-standard-with-typescript": "^22.0.0",


### PR DESCRIPTION
In order to use CS:GO Tunes, the user needs to have a CFG file that they can placed into the CS:GO config folder. This commit adds a button to generate and download it.