### PR TITLE
Website: Support for enabling and disabled on dashboard

### DIFF
--- a/Website/Source/Index.tsx
+++ b/Website/Source/Index.tsx
@@ -2,13 +2,14 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import { App } from './App';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import i18n from './Utils/I18N';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min';
 import 'bootstrap-icons/font/bootstrap-icons.css';
 import './Index.css';
+
+console.log(i18n);
 
 const app = document.getElementById('app');
 ReactDOM.render(<App />, app);

--- a/Website/Source/Models/UpdateUserProfileRequest.ts
+++ b/Website/Source/Models/UpdateUserProfileRequest.ts
@@ -1,0 +1,3 @@
+export interface UpdateUserProfileRequest {
+  isDisabled: boolean
+}

--- a/Website/Source/Models/UserProfileResponse.ts
+++ b/Website/Source/Models/UserProfileResponse.ts
@@ -2,5 +2,5 @@ export interface UserProfileResponse {
   spotifyUserID: string
   cfgKey: string
   lastSeenAt: string
-  isDisabled: string
+  isDisabled: boolean
 }

--- a/Website/Source/Translations/en.json
+++ b/Website/Source/Translations/en.json
@@ -5,5 +5,7 @@
   "loading": "Loading...",
   "dashboard_welcome": "Welcome to the dashboard.",
   "download_cfg_button": "Download CFG",
-  "disclaimer": "CS:GO Tunes is not affiliated with Valve or Spotify."
+  "disclaimer": "CS:GO Tunes is not affiliated with Valve or Spotify.",
+  "enable_button": "Enable CS:GO Tunes",
+  "disable_button": "Disable CS:GO Tunes"
 }

--- a/Website/Source/Translations/gr.json
+++ b/Website/Source/Translations/gr.json
@@ -5,5 +5,7 @@
   "loading": "Loading...",
   "dashboard_welcome": "Welcome to the dashboard.",
   "download_cfg_button": "Download CFG",
-  "disclaimer": "CS:GO Tunes is not affiliated with Valve or Spotify."
+  "disclaimer": "CS:GO Tunes is not affiliated with Valve or Spotify.",
+  "enable_button": "Enable CS:GO Tunes",
+  "disable_button": "Disable CS:GO Tunes"
 }


### PR DESCRIPTION
This commit adds support for enabling and disabling CS:GO Tunes via a button on the user's dashboard.

Fixes #5 