### PR TITLE
Website: Add textarea with config contents and copy to clipboard button

### DIFF
--- a/Website/Source/Pages/DashboardPage.tsx
+++ b/Website/Source/Pages/DashboardPage.tsx
@@ -6,14 +6,14 @@ import FileSaver from 'file-saver';
 import { clearSession, getSession } from '../Utils/AuthUtils';
 import { useTranslation } from 'react-i18next';
 import { UpdateUserProfileRequest } from '../Models/UpdateUserProfileRequest';
+import copy from 'copy-to-clipboard';
 
 export const DashboardPage: React.FunctionComponent<any> = () => {
   const history = useHistory();
   const [isLoading, setLoading] = useState(false);
   const [isDisabled, setDisabled] = useState(false);
   const [isSettingDisabledPreference, setSettingDisabledPreference] = useState(false);
-  const [spotifyUserID, setSpotifyUserID] = useState<string | null>(null);
-  const [cfgKey, setCFGKey] = useState<string | null>(null);
+  const [configContents, setConfigContents] = useState<string | null>(null);
 
   const { t } = useTranslation();
 
@@ -50,9 +50,37 @@ export const DashboardPage: React.FunctionComponent<any> = () => {
         }
 
         const userProfileResponse: UserProfileResponse = await response.json();
-        setSpotifyUserID(userProfileResponse.spotifyUserID);
-        setCFGKey(userProfileResponse.cfgKey);
         setDisabled(userProfileResponse.isDisabled);
+
+        const encodedSpotifyUserId = encodeURIComponent(userProfileResponse.spotifyUserID);
+        const encodedCFGKey = encodeURIComponent(userProfileResponse.cfgKey);
+
+        const userConfig = `"CS:GO Tunes"
+{
+ "uri" "https://csgotunes.azurewebsites.net/api/game-state?spotifyUserID=${encodedSpotifyUserId}&cfgKey=${encodedCFGKey}"
+ "timeout" "5.0"
+ "buffer"  "0.1"
+ "throttle" "0.5"
+ "heartbeat" "60.0"
+ "output"
+ {
+   "precision_time" "3"
+   "precision_position" "1"
+   "precision_vector" "3"
+ }
+ "data"
+ {
+   "provider"            "1"      // general info about client being listened to: game name, appid, client steamid, etc.
+   "map"                 "1"      // map, gamemode, and current match phase ('warmup', 'intermission', 'gameover', 'live') and current score
+   "round"               "1"      // round phase ('freezetime', 'over', 'live'), bomb state ('planted', 'exploded', 'defused'), and round winner (if any)
+   "player_id"           "1"      // player name, clan tag, observer slot (ie key to press to observe this player) and team
+   "player_state"        "1"      // player state for this current round such as health, armor, kills this round, etc.
+   "player_weapons"      "1"      // output equipped weapons.
+   "player_match_stats"  "1"      // player stats this match such as kill, assists, score, deaths and MVPs
+ }
+}`;
+
+        setConfigContents(userConfig);
       } finally {
         setLoading(false);
       }
@@ -96,49 +124,30 @@ export const DashboardPage: React.FunctionComponent<any> = () => {
   };
 
   const downloadConfig = (e: MouseEvent<HTMLButtonElement>): void => {
-    if (spotifyUserID === null || cfgKey === null) {
+    if (configContents === null) {
       return;
     }
 
-    const encodedSpotifyUserId = encodeURIComponent(spotifyUserID);
-    const encodedCFGKey = encodeURIComponent(cfgKey);
-
-    const userConfig = `
-"CS:GO Tunes"
-{
- "uri" "https://csgotunes.azurewebsites.net/api/game-state?spotifyUserID=${encodedSpotifyUserId}&cfgKey=${encodedCFGKey}"
- "timeout" "5.0"
- "buffer"  "0.1"
- "throttle" "0.5"
- "heartbeat" "60.0"
- "output"
- {
-   "precision_time" "3"
-   "precision_position" "1"
-   "precision_vector" "3"
- }
- "data"
- {
-   "provider"            "1"      // general info about client being listened to: game name, appid, client steamid, etc.
-   "map"                 "1"      // map, gamemode, and current match phase ('warmup', 'intermission', 'gameover', 'live') and current score
-   "round"               "1"      // round phase ('freezetime', 'over', 'live'), bomb state ('planted', 'exploded', 'defused'), and round winner (if any)
-   "player_id"           "1"      // player name, clan tag, observer slot (ie key to press to observe this player) and team
-   "player_state"        "1"      // player state for this current round such as health, armor, kills this round, etc.
-   "player_weapons"      "1"      // output equipped weapons.
-   "player_match_stats"  "1"      // player stats this match such as kill, assists, score, deaths and MVPs
- }
-}
-        `;
-
-    const blob = new Blob([userConfig], {
+    const blob = new Blob([configContents], {
       type: 'text/plain;charset=utf-8'
     });
     FileSaver.saveAs(blob, 'gamestate_integration_csgotunes.cfg');
   };
+
+  const copyConfig = (e: MouseEvent<HTMLButtonElement>): void => {
+    if (configContents === null) {
+      return;
+    }
+
+    copy(configContents);
+  };
   return (
     <div>
       <p>{t('dashboard_welcome')}</p>
-      <button onClick={downloadConfig} disabled={isLoading}>{t('download_cfg_button')}</button>
+      <div>
+        <button onClick={downloadConfig} disabled={isLoading}>{t('download_cfg_button')}</button>
+      </div>
+      <div>
       {isDisabled
         ? (
             <button onClick={(e: MouseEvent<HTMLButtonElement>) => setDisabledPreference(false)} disabled={isLoading}>{t('enable_button')}</button>
@@ -146,6 +155,13 @@ export const DashboardPage: React.FunctionComponent<any> = () => {
         : (
         <button onClick={(e: MouseEvent<HTMLButtonElement>) => setDisabledPreference(true)} disabled={isLoading || isSettingDisabledPreference}>{t('disable_button')}</button>
           )}
+      </div>
+      <div>
+        <textarea value={configContents === null ? '' : configContents} readOnly={true} />
+      </div>
+      <div>
+        <button onClick={copyConfig} disabled={isLoading}>{t('copy_cfg_to_clipboard_button')}</button>
+      </div>
     </div>
   );
 };

--- a/Website/Source/Translations/en.json
+++ b/Website/Source/Translations/en.json
@@ -5,6 +5,7 @@
   "loading": "Loading...",
   "dashboard_welcome": "Welcome to the dashboard.",
   "download_cfg_button": "Download CFG",
+  "copy_cfg_to_clipboard_button": "Copy CFG to Clipboard",
   "disclaimer": "CS:GO Tunes is not affiliated with Valve or Spotify.",
   "enable_button": "Enable CS:GO Tunes",
   "disable_button": "Disable CS:GO Tunes"

--- a/Website/Source/Translations/gr.json
+++ b/Website/Source/Translations/gr.json
@@ -5,6 +5,7 @@
   "loading": "Loading...",
   "dashboard_welcome": "Welcome to the dashboard.",
   "download_cfg_button": "Download CFG",
+  "copy_cfg_to_clipboard_button": "Copy CFG to Clipboard",
   "disclaimer": "CS:GO Tunes is not affiliated with Valve or Spotify.",
   "enable_button": "Enable CS:GO Tunes",
   "disable_button": "Disable CS:GO Tunes"

--- a/Website/package-lock.json
+++ b/Website/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "bootstrap": "^5.2.0",
         "bootstrap-icons": "^1.9.1",
+        "copy-to-clipboard": "^3.3.2",
         "file-saver": "^2.0.5",
         "i18next": "^21.9.2",
         "i18next-browser-languagedetector": "^6.1.5",
@@ -2454,6 +2455,14 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.2.tgz",
+      "integrity": "sha512-Vme1Z6RUDzrb6xAI7EZlVZ5uvOk2F//GaxKUxajDqm9LhOVM1inxNAD2vy+UZDYsd0uyA9s7b3/FVZPSxqrCfg==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -5281,6 +5290,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -7108,6 +7122,14 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "copy-to-clipboard": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.2.tgz",
+      "integrity": "sha512-Vme1Z6RUDzrb6xAI7EZlVZ5uvOk2F//GaxKUxajDqm9LhOVM1inxNAD2vy+UZDYsd0uyA9s7b3/FVZPSxqrCfg==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -9150,6 +9172,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "tsconfig-paths": {
       "version": "3.14.1",

--- a/Website/package.json
+++ b/Website/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "bootstrap": "^5.2.0",
     "bootstrap-icons": "^1.9.1",
+    "copy-to-clipboard": "^3.3.2",
     "file-saver": "^2.0.5",
     "i18next": "^21.9.2",
     "i18next-browser-languagedetector": "^6.1.5",


### PR DESCRIPTION
As recommended by issue #14, this commit adds a textarea with the contents of the CFG file (as well as a button to copy to clipboard) which allows users to create the gamestate integration configuration themselves if they are not fond on downloading the automatically generated file.